### PR TITLE
oauth token can now be retrieved via post request

### DIFF
--- a/src/main/java/com/jersey/Authorization/Config/OAuth2Configuration.java
+++ b/src/main/java/com/jersey/Authorization/Config/OAuth2Configuration.java
@@ -88,9 +88,7 @@ public class OAuth2Configuration {
 
         @Override
         public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
-
-            endpoints.allowedTokenEndpointRequestMethods(HttpMethod.GET);
-
+            
             endpoints
                     .tokenStore(tokenStore())
                     .authenticationManager(authenticationManager);


### PR DESCRIPTION
Now the access token will be retrieved via a post request instead of a get request which is the standard way of doing it